### PR TITLE
fix(config):  vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,7 +40,7 @@
             },
             "osx": {
                 "args": [
-                    "config=release_ARM64"
+                    "config=release_arm64"
                 ],
             },
             "group": "build",


### PR DESCRIPTION
## Description

When I attempt to run the `build release` task from VSCode, the following error occurs:

<img width="917" alt="Screenshot 2024-11-20 at 7 56 43 PM" src="https://github.com/user-attachments/assets/73ff7845-80c1-4d76-82fa-15cab095456c">

## Changes

- Fixed a mismatched argument used to run the autogenerated Makefile: `"config=release_arm64"`