### PR TITLE
Use mingw32-make in build-MinGW-W64.bat

### DIFF
--- a/build-MinGW-W64.bat
+++ b/build-MinGW-W64.bat
@@ -1,5 +1,5 @@
 cd build
 premake5.exe gmake2
 cd ..
-make SHELL=CMD clean
+mingw32-make SHELL=CMD clean
 pause


### PR DESCRIPTION
Not all mingw-w64 toolchains on windows are guaranteed to have make, but virtually all of them have mingw32-make. MSYS2 UCRT does not provide make, but does provide mingw32-make. So users who have added UCRT to the PATH (Not advisable!) but not msys64 will have errors about a missing make.

VSCode's tasks.json uses mingw32-make anyway, so it's better to stay consistent with it.