### PR TITLE
Remove SHELL=cmd hacks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,9 +9,6 @@
             "command": "make",
             "windows": {
                 "command": "mingw32-make.exe",
-                "args": [
-                    "SHELL=cmd"
-                ],
             },
             "osx": {
                 "args": [
@@ -34,7 +31,6 @@
             "windows": {
                 "command": "mingw32-make.exe",
                 "args": [
-                    "SHELL=cmd",
                     "config=release_x64"
                 ],
             },
@@ -61,7 +57,6 @@
             "windows": {
                 "command": "mingw32-make.exe",
                 "args": [
-                    "SHELL=cmd",
                     "clean"
                 ],
             },

--- a/build-MinGW-W64.bat
+++ b/build-MinGW-W64.bat
@@ -1,5 +1,5 @@
 cd build
 premake5.exe gmake2
 cd ..
-mingw32-make SHELL=CMD clean
+mingw32-make clean
 pause


### PR DESCRIPTION
These are not required anymore, now that premake is updated.

Fixed in:
https://github.com/premake/premake-core/pull/2039